### PR TITLE
Add github action to do yaml syntax check

### DIFF
--- a/.github/workflows/yaml-check.yaml
+++ b/.github/workflows/yaml-check.yaml
@@ -1,0 +1,21 @@
+name: Check yaml
+on: [push]
+
+jobs:
+  yamlcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          pip install pyyaml
+      - name: check yaml
+        # Apparently, if you do this using "find -exec" in one
+        # command, it does not exit with a failure status.
+        run: |
+          find . -type f \( -name '*.yaml' -o -name '*.yml' \) -print0 | xargs -0 -i python -c "import yaml ; yaml.safe_load(open('{}'))" || exit 1


### PR DESCRIPTION
- Use Python yaml.safe_load to check all YAML file syntax on each
  commit.

- I tried one other publish gh-action for yaml checker, but it seemed
  too strict (wanted line 7 of data to be intented more).  Rather than
  constrict us too much, I used this previous action I have made
  before - that has no external dependencies.

- This can certainly be made more advanced later.  If we are willing
  to accept more strict syntax, we can use
  https://github.com/marketplace/actions/yaml-lint